### PR TITLE
Fix #139

### DIFF
--- a/src/main/java/es/ubu/lsi/ubumonitor/util/UtilMethods.java
+++ b/src/main/java/es/ubu/lsi/ubumonitor/util/UtilMethods.java
@@ -154,8 +154,8 @@ public class UtilMethods {
 	 * @param stringToRemove need to remove reserved character
 	 * @return without reserved character
 	 */
-	public static String removeReservedChar(String stringToRemove) {
-		String newString = stringToRemove.replaceAll(":|\\\\|/|\\?|\\*|\\|", "");
+	public static String removeReservedChar(String stringToRemove) {		
+		String newString = stringToRemove.replaceAll("\"|\\||<|>|:|\\\\|/|\\?|\\*|\\|", ""); // FIX #139 added more dangerous characters 
 		return newString.trim();
 		
 	}

--- a/src/test/java/es/ubu/lsi/ubumonitor/UnitTest.java
+++ b/src/test/java/es/ubu/lsi/ubumonitor/UnitTest.java
@@ -57,6 +57,9 @@ public class UnitTest {
 		fillMap(map, "Inglés EPS VENA-curso 2019:20", "Inglés EPS VENA-curso 201920");
 		fillMap(map, "Inglés EPS\\ VENA-curso 2019:20", "Inglés EPS VENA-curso 201920");
 		fillMap(map, "Inglés EPS ?VENA-curso 2019:20", "Inglés EPS VENA-curso 201920");
+		fillMap(map, "Inglés EPS \"VENA-curso 2019:20\"", "Inglés EPS VENA-curso 201920");
+		fillMap(map, "Inglés EPS <VENA-curso 2019:20>", "Inglés EPS VENA-curso 201920");
+		fillMap(map, "Inglés EPS |VENA-curso 2019:20|", "Inglés EPS VENA-curso 201920");
 		for (Map.Entry<String, String> entry : map.entrySet()) {
 			assertEquals(entry.getValue(), entry.getKey());
 		}


### PR DESCRIPTION
Replaced other dangerous characters (i.e. ", <, > and |) in course name to be used as file path. Updated tests.